### PR TITLE
Feat/142 provide spendable reveal and reclaim paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "sbtc-bridge-web",
 			"version": "0.0.1",
 			"dependencies": {
+				"@noble/curves": "^1.0.0",
 				"@noble/secp256k1": "^2.0.0",
 				"@scure/base": "^1.1.1",
 				"@scure/bip32": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"postcss-cli": "^10.0.0",
 				"process": "^0.11.10",
 				"readable-stream": "^4.3.0",
-				"sbtc-bridge-lib": "^1.0.11",
+				"sbtc-bridge-lib": "^1.0.12",
 				"svelte-bootstrap-icons": "^2.3.1",
 				"svelte-json-tree": "^1.0.0",
 				"svelte-local-storage-store": "^0.4.0",
@@ -9746,9 +9746,9 @@
 			}
 		},
 		"node_modules/sbtc-bridge-lib": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.0.11.tgz",
-			"integrity": "sha512-A9ZOZuf4fREtPYrdLqYLgOhJlBgS6c8qj6DoEew+hnm0ZdwzHnm1xgIuhPszhm2HldpaSUaXMVMXEkMdPwoLkQ==",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.0.12.tgz",
+			"integrity": "sha512-YLI6MGqKWLBiGt15q/Bbo2WCJYSYVcNBpXOiDltiADszTcjj0Mgjlj76xvYf0qEkQMIYezhdEX5LYNnnjOp3bQ==",
 			"dependencies": {
 				"@noble/secp256k1": "^2.0.0",
 				"@scure/base": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"vitest-fetch-mock": "^0.2.1"
 	},
 	"dependencies": {
+		"@noble/curves": "^1.0.0",
 		"@noble/secp256k1": "^2.0.0",
 		"@scure/base": "^1.1.1",
 		"@scure/bip32": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"postcss-cli": "^10.0.0",
 		"process": "^0.11.10",
 		"readable-stream": "^4.3.0",
-		"sbtc-bridge-lib": "^1.0.11",
+		"sbtc-bridge-lib": "^1.0.12",
 		"svelte-bootstrap-icons": "^2.3.1",
 		"svelte-json-tree": "^1.0.0",
 		"svelte-local-storage-store": "^0.4.0",

--- a/src/lib/bridge_api.ts
+++ b/src/lib/bridge_api.ts
@@ -1,11 +1,10 @@
 import { CONFIG } from '$lib/config';
-import type { PeginRequestI } from 'sbtc-bridge-lib' 
+import type { PeginRequestI, WrappedPSBT } from 'sbtc-bridge-lib' 
 
 function addNetSelector (path:string) {
   if (CONFIG.VITE_NETWORK === 'testnet' || CONFIG.VITE_NETWORK === 'devnet') {
     return path.replace('bridge-api', 'bridge-api/testnet');
-  }
-  else {
+  } else {
     return path.replace('bridge-api', 'bridge-api/mainnet');
   }
 }
@@ -57,6 +56,58 @@ export async function sendRawTransaction(tx: { hex: string; }) {
     throw new Error('Bitcoin tx send error.');
   }
   return await extractResponse(response);
+}
+
+export async function fetchKeys() {
+  const path = addNetSelector(CONFIG.VITE_BRIDGE_API + '/btc/tx/keys');
+  const response = await fetch(path);
+  if (response.status !== 200) {
+    throw new Error('Bitcoin address not known - is the network correct?');
+  }
+  const res = await extractResponse(response);
+  return res;
+}
+
+export async function signAndBroadcast(wrappedPsbt:WrappedPSBT) {
+  const path = addNetSelector(CONFIG.VITE_BRIDGE_API + '/btc/tx/signAndBroadcast');
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(wrappedPsbt)
+  });
+  let res:any;
+  try {
+    res = await response.json();
+  } catch (err) {
+    try {
+      console.log(err)
+      res = await response.text();
+    } catch (err1) {
+      console.log(err1)
+    }
+  }
+  return res;
+}
+
+export async function sign(wrappedPsbt:WrappedPSBT) {
+  const path = addNetSelector(CONFIG.VITE_BRIDGE_API + '/btc/tx/sign');
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(wrappedPsbt)
+  });
+  let res:any;
+  try {
+    res = await response.json();
+  } catch (err) {
+    try {
+      console.log(err)
+      res = await response.text();
+    } catch (err1) {
+      console.log(err1)
+    }
+  }
+  return res;
 }
 
 export async function fetchBurnBlockCount() {

--- a/src/lib/components/common/UTXOSelection.svelte
+++ b/src/lib/components/common/UTXOSelection.svelte
@@ -24,12 +24,12 @@ let showUtxos:boolean;
 let showDebugInfo = $sbtcConfig.userSettings.debugMode;
 
 const useWebWallet = async () => {
-  bitcoinAddress = addresses().ordinal;
+  bitcoinAddress = addresses().cardinal;
   configureUTXOs(true);
 }
 
 const isWebWallet = async () => {
-  return (bitcoinAddress === addresses().ordinal);
+  return (bitcoinAddress === addresses().cardinal);
 }
 
 const configureUTXOs = async (force:boolean) => {
@@ -38,7 +38,7 @@ const configureUTXOs = async (force:boolean) => {
   try {
     isSupported(bitcoinAddress);
   } catch (err:any) {
-    //bitcoinAddress = addresses().ordinal;
+    //bitcoinAddress = addresses().cardinal;
     errorReason = 'Unsupported bitcoin address - the reclaim feature currently requires a taproot (segwit v1) bitcoin addresses.';
     return;
   }
@@ -86,7 +86,7 @@ onMount(async () => {
     {#if bitcoinAddress && errorReason}
       <div>
         <div class="text-warning">{errorReason}
-          <a href="/" class="text-underline text-warning" style="text-transform: uppercase" on:click|preventDefault={() => useWebWallet()}>reset address to your web wallet ordinal (taproot) address</a>
+          <a href="/" class="text-underline text-warning" style="text-transform: uppercase" on:click|preventDefault={() => useWebWallet()}>reset address to your web wallet cardinal (taproot) address</a>
         </div>
       </div>
     {/if}

--- a/src/lib/components/reclaim/TrCommit.svelte
+++ b/src/lib/components/reclaim/TrCommit.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import { tsToDate, truncate, explorerBtcTxUrl, explorerBtcAddressUrl } from '$lib/utils'
+import { tsToDate, explorerBtcTxUrl, explorerBtcAddressUrl } from '$lib/utils'
 import * as btc from '@scure/btc-signer';
 import type { PeginRequestI } from 'sbtc-bridge-lib' 
-import { CONFIG } from '$lib/config';
-import { addressFromPubkey, parseDepositPayload } from 'sbtc-bridge-lib' 
-import TxExport from './TxExport.svelte';
-import { sbtcConfig } from '$stores/stores'
+import { parseDepositPayload } from 'sbtc-bridge-lib' 
 
 export let peginRequest:PeginRequestI;
-export let reclaimBtcTx:btc.Transaction;
-export let revealBtcTx:btc.Transaction;
 let stacksData:any;
 let intid = false;
 let showCommitDetails = false;
@@ -22,11 +17,7 @@ onMount(() => {
     const revealScript = btc.Script.decode(peginRequest.commitTxScript?.leaves[0].script);
     const reclaimScript = btc.Script.decode(peginRequest.commitTxScript?.leaves[1].script);
     for (let part of reclaimScript) {
-      if (typeof part === 'object') {
-        reclaimString += addressFromPubkey(CONFIG.VITE_NETWORK, part) + ' ';
-      } else {
-        reclaimString += part + ' ';
-      }
+      reclaimString += part + ' ';
     }
     
     let count = 0;
@@ -34,26 +25,12 @@ onMount(() => {
       if (count === 0) {
         revealString += '<stacks_data> ';
       } else {
-        if (typeof part === 'object') {
-          revealString += addressFromPubkey(CONFIG.VITE_NETWORK, part) + ' ';
-        } else {
-          revealString += part + ' ';
-        }
+        revealString += part + ' ';
       }
       count++;
     }
     const amt = (peginRequest.vout && peginRequest.vout.value) ? peginRequest.vout.value : peginRequest.amount;
     stacksData = parseDepositPayload(revealScript[0].valueOf() as Uint8Array, amt);
-    /**
-    const d1U = stacksData;
-    d3 = hex.encode(stacksData);
-    const index = 0;
-    const addr0 = parseInt(hex.encode(d1U.subarray(index + 1, index + 2)), 16);
-    const addr1 = hex.encode(d1U.subarray(index + 2, index + 22));
-    stacksAddress = c32address(addr0, addr1);
-    cnameBuf = new TextDecoder().decode(d1U.subarray(index + 22, index + 56));
-    revealFee = parseInt(hex.encode(d1U.subarray(index + 56, index + 84)), 16);
-    */
   } catch(err) {
     console.log(err)
   }
@@ -65,12 +42,6 @@ onMount(() => {
 {#if intid}
 <div class="row ">
   <div class="col-12 mt-0 mb-2">Commitment Transaction: {tsToDate(peginRequest.updated)}</div>
-  <!--
-  {#each scriptElements as element}
-  <div class="col-md-2 col-sm-12 text-info">{element.key}</div>
-  <div class="col-md-10 col-sm-12">{element.value}</div>
-  {/each}
-  -->
   {#if peginRequest.btcTxid}
   <div class="col-md-2 col-sm-12 text-info">Sent To</div><div class="col-md-10 col-sm-12">
     <a href={explorerBtcTxUrl(peginRequest.btcTxid)} target="_blank" rel="noreferrer">{(peginRequest.commitTxScript?.address)}</a>
@@ -86,58 +57,11 @@ onMount(() => {
     <a href={explorerBtcTxUrl(peginRequest.reveal?.btcTxid)} target="_blank" rel="noreferrer">{(peginRequest.reveal?.btcTxid)}</a>
   </div>
   {/if}
-  <div class="col-12 text-start"><span class="pointer" on:keypress on:click={() => showCommitDetails = !showCommitDetails}>show details</span></div>
   {:else}
   <div class="col-md-2 col-sm-12 text-info">Sends To</div><div class="col-md-10 col-sm-12">
     <a href={explorerBtcAddressUrl(peginRequest.commitTxScript?.address || '')} target="_blank" rel="noreferrer">{(peginRequest.commitTxScript?.address)}</a>
   </div>
   {/if}
-  
-  {#if showCommitDetails}
-  <div class="mt-4 col-12">Reclaim Data</div>
-  <div class="col-md-2 col-sm-12 text-info">Reclaim Address</div><div class="col-md-10 col-sm-12">{peginRequest.fromBtcAddress}</div>
-  {#if stacksData && $sbtcConfig.userSettings.debugMode}
-  <div class="col-md-2 col-sm-12 text-info">Reclaim Pub Key</div><div class="col-md-10 col-sm-12">{peginRequest.reclaimPub}</div>
-  <div class="col-md-2 col-sm-12 text-info">Reclaim Script</div><div class="col-md-10 col-sm-12">{reclaimString}</div>
-  {/if}
-  {#if peginRequest.status < 3}
-  <TxExport btcTx={reclaimBtcTx} txtype={'reclaim'} amount={peginRequest.vout?.value || 0}/>
-  {/if}
-  <div class="mt-4 col-12">Reveal Data</div>
-  <div class="col-md-2 col-sm-12 text-info">Sbtc Address</div><div class="col-md-10 col-sm-12">{peginRequest.sbtcWalletAddress}</div>
-  {#if stacksData && $sbtcConfig.userSettings.debugMode}
-  <div class="col-md-2 col-sm-12 text-info">Reveal Pub Key</div><div class="col-md-10 col-sm-12">{peginRequest.revealPub}</div>
-  <div class="col-md-2 col-sm-12 text-info">Reveal Script</div><div class="col-md-10 col-sm-12">{revealString}</div>
-  {/if}
-  <div class="mt-4 col-12 text-info"></div>
-  {#if peginRequest.status < 3}
-  <TxExport btcTx={revealBtcTx} txtype={'reveal'} amount={peginRequest.vout?.value || 0}/>
-  {/if}
-  {#if stacksData && $sbtcConfig.userSettings.debugMode}
-  <div class="mt-4 col-12">Stacks Data</div>
-  <div class="col-md-2 col-sm-12 text-info">Op Code</div><div class="col-md-10 col-sm-12">{stacksData.opcode}</div>
-  <div class="col-md-2 col-sm-12 text-info">Address</div><div class="col-md-10 col-sm-12">{stacksData.stacksAddress}</div>
-  <div class="col-md-2 col-sm-12 text-info">Contract Name</div><div class="col-md-10 col-sm-12">{stacksData.cname || 'n/a'}</div>
-  <div class="col-md-2 col-sm-12 text-info">Memo</div><div class="col-md-10 col-sm-12">{stacksData.memo || 'n/a'}</div>
-  <div class="col-md-2 col-sm-12 text-info">Reveal Fee</div><div class="col-md-10 col-sm-12">{stacksData.revealFee}</div>
-  {/if}
-  {/if}
-  <!--
-  <div class="col-md-2 col-sm-12 text-info">Stacks addr</div><div class="col-md-10 col-sm-12">{stacksAddress}</div>
-  <div class="col-md-2 col-sm-12 text-info">Stacks contract</div><div class="col-md-10 col-sm-12">{cnameBuf}</div>
-  <div class="col-md-2 col-sm-12 text-info">Reveal Fee</div><div class="col-md-10 col-sm-12">{revealFee}</div>
-  <div class="col-md-2 col-sm-12 text-info">For</div><div class="col-md-10 col-sm-12">{peginRequest.amount} Sats</div>
-  <div class="col-md-2 col-sm-12 text-info">SBTC Wallet</div><div class="col-md-10 col-sm-12">{peginRequest.sbtcWalletAddress}</div>
-  <div class="col-12 mt-4 mb-2">Witness Data</div>
-  <div class="col-md-2 col-sm-12 text-info">Full Script</div><div class="col-md-10 col-sm-12">{peginRequest.commitTxScript?.witnessScript}</div>
-  <div class="col-md-2 col-sm-12 text-info">Witness Script</div><div class="col-md-10 col-sm-12">{d1}<br/>{d2}<br/>{d3}</div>
-  <div class="col-12 mt-4 mb-2">Commit Transaction</div>
-  <div class="col-md-2 col-sm-12 text-info">scriptpubkey_type</div><div class="col-md-10 col-sm-12">{peginRequest.vout?.scriptpubkey_type}</div>
-  <div class="col-md-2 col-sm-12 text-info">scriptpubkey</div><div class="col-md-10 col-sm-12">{peginRequest.vout?.scriptpubkey}</div>
-  <div class="col-md-2 col-sm-12 text-info">scriptpubkey_asm</div><div class="col-md-10 col-sm-12">{peginRequest.vout?.scriptpubkey_asm}</div>
-  <div class="col-md-2 col-sm-12 text-info">scriptpubkey_address</div><div class="col-md-10 col-sm-12">{peginRequest.vout?.scriptpubkey_address}</div>
-  <div class="col-md-2 col-sm-12 text-info">value</div><div class="col-md-10 col-sm-12">{peginRequest.vout?.value}</div>
-  -->
 </div>
 {/if}
 

--- a/src/lib/components/reclaim/TrRevealReclaim.svelte
+++ b/src/lib/components/reclaim/TrRevealReclaim.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { tsToDate } from '$lib/utils'
+import * as btc from '@scure/btc-signer';
+import type { PeginRequestI } from 'sbtc-bridge-lib' 
+import { parseDepositPayload } from 'sbtc-bridge-lib' 
+import TxExport from './TxExport.svelte';
+import { sbtcConfig } from '$stores/stores'
+
+export let peginRequest:PeginRequestI;
+export let reclaimBtcTx:btc.Transaction;
+export let revealBtcTx:btc.Transaction;
+let stacksData:any;
+let intid = false;
+let showCommitDetails = false;
+
+let reclaimString = '';
+let revealString = '';
+onMount(() => {
+  try {
+    const revealScript = btc.Script.decode(peginRequest.commitTxScript?.leaves[0].script);
+    const reclaimScript = btc.Script.decode(peginRequest.commitTxScript?.leaves[1].script);
+    for (let part of reclaimScript) {
+      reclaimString += part + ' ';
+    }
+    
+    let count = 0;
+    for (let part of revealScript) {
+      if (count === 0) {
+        revealString += '<stacks_data> ';
+      } else {
+        revealString += part + ' ';
+      }
+      count++;
+    }
+    const amt = (peginRequest.vout && peginRequest.vout.value) ? peginRequest.vout.value : peginRequest.amount;
+    stacksData = parseDepositPayload(revealScript[0].valueOf() as Uint8Array, amt);
+  } catch(err) {
+    console.log(err)
+  }
+  intid = true;
+})
+
+</script>
+
+{#if intid}
+<div class="row ">
+  <!--
+  {#each scriptElements as element}
+  <div class="col-md-2 col-sm-12 text-info">{element.key}</div>
+  <div class="col-md-10 col-sm-12">{element.value}</div>
+  {/each}
+  -->
+  <div class="col-12 text-start"><span class="pointer" on:keypress on:click={() => showCommitDetails = !showCommitDetails}>show details</span></div>
+  {#if showCommitDetails}
+  <div class="mt-4 col-12">Reclaim Data</div>
+  <div class="col-md-2 col-sm-12 text-info">Refunds to</div><div class="col-md-10 col-sm-12">{peginRequest.senderAddress}</div>
+  {#if stacksData && $sbtcConfig.userSettings.debugMode}
+  <div class="col-md-2 col-sm-12 text-info">Reclaim Pub Key</div><div class="col-md-10 col-sm-12">{peginRequest.reclaimPub}</div>
+  {/if}
+  {#if peginRequest.status < 3}
+  <TxExport btcTx={reclaimBtcTx} txtype={'reclaim'} amount={peginRequest.vout?.value || 0}/>
+  {/if}
+  <div class="mt-4 col-12">Reveal Data</div>
+  <div class="col-md-2 col-sm-12 text-info">Sbtc Address</div><div class="col-md-10 col-sm-12">{peginRequest.sbtcWalletAddress}</div>
+  {#if stacksData && $sbtcConfig.userSettings.debugMode}
+  <div class="col-md-2 col-sm-12 text-info">Reveal Pub Key</div><div class="col-md-10 col-sm-12">{peginRequest.revealPub}</div>
+  {/if}
+  <div class="mt-4 col-12 text-info"></div>
+  {#if peginRequest.status < 3}
+  <TxExport btcTx={revealBtcTx} txtype={'reveal'} amount={peginRequest.vout?.value || 0}/>
+  {/if}
+    {#if stacksData && $sbtcConfig.userSettings.debugMode}
+    <div class="mt-4 col-12">Stacks Data</div>
+    <div class="col-md-2 col-sm-12 text-info">Op Code</div><div class="col-md-10 col-sm-12">{stacksData.opcode}</div>
+    <div class="col-md-2 col-sm-12 text-info">Address</div><div class="col-md-10 col-sm-12">{stacksData.stacksAddress}</div>
+    <div class="col-md-2 col-sm-12 text-info">Contract Name</div><div class="col-md-10 col-sm-12">{stacksData.cname || 'n/a'}</div>
+    <div class="col-md-2 col-sm-12 text-info">Memo</div><div class="col-md-10 col-sm-12">{stacksData.memo || 'n/a'}</div>
+    <div class="col-md-2 col-sm-12 text-info">Reveal Fee</div><div class="col-md-10 col-sm-12">{stacksData.revealFee}</div>
+    {/if}
+  {/if}
+</div>
+{/if}
+
+<style>
+</style>

--- a/src/lib/components/reclaim/TxExport.svelte
+++ b/src/lib/components/reclaim/TxExport.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { hex, base64 } from '@scure/base';
-import { addressFromPubkey } from 'sbtc-bridge-lib' 
 import type { Transaction } from '@scure/btc-signer' 
-import { CONFIG } from '$lib/config';
 import * as btc from '@scure/btc-signer';
 
 export let btcTx:Transaction;
@@ -22,9 +20,9 @@ const pubKeyFromTapLeafScript = () => {
   const tapLeafScripts = btcTx.getInput(0).tapLeafScript;
   if (!tapLeafScripts) return;
   let cb:Uint8Array;
-  if (txtype === 'reveal') { 
+  if (txtype === 'reveal') {
     cb = tapLeafScripts[0][1]
-  } else { 
+  } else {
     cb = tapLeafScripts[1][1]
   }
   cb = cb.subarray(0, cb.length - 1); // strip out the last byte of control block
@@ -41,7 +39,6 @@ const pubKeyFromTapLeafScript = () => {
 const localAddressFromPubkey = () => {
   const pubkey:any = pubKeyFromTapLeafScript()
   if (!pubkey || typeof pubkey !== 'object') return;
-  //const address = addressFromPubkey(CONFIG.VITE_NETWORK, pubkey)
 	return hex.encode(pubkey)
 }
 
@@ -78,15 +75,15 @@ onMount(() => {
   <div class="row">
     {#each Array(btcTx.outputsLength) as _, index (index)}
     <div class="col-12">
-      <div>Sends {btcTx.getOutput(index).amount} sats to {localAddressFromPubkey()}</div>
+      <div>To public key: {localAddressFromPubkey()}</div>
     </div>
     {/each}
   </div>
   {#if !showHex}
-  <div class="row">
+  <div class="mt-5 row">
     <div class="col">
       <div class="d-flex justify-content-between">
-        <p>{txtype} PSBT (Base 64)</p>
+        <p>PSBT (Base 64)</p>
         <span class="pointer" on:keydown on:click={() => showHex = !showHex}>{#if showHex}Show Base 64{:else}Show Hex{/if}</span>
       </div>
       <textarea rows="6" style="padding: 10px; width: 100%;" readonly>{b64Reveal()}</textarea>
@@ -96,7 +93,7 @@ onMount(() => {
   <div class="row">
     <div class="col">
       <div class="d-flex justify-content-between">
-        <p>{txtype} PSBT (Hex)</p>
+        <p>PSBT (Hex)</p>
         <span class="pointer" on:keydown on:click={() => showHex = !showHex}>{#if showHex}Show Base 64{:else}Show Hex{/if}</span>
       </div>
       <textarea rows="6" style="padding: 10px; width: 100%;" readonly>{rawReveal()}</textarea>

--- a/src/lib/components/wrapper/BuildTransaction.svelte
+++ b/src/lib/components/wrapper/BuildTransaction.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { CONFIG } from '$lib/config';
 import { onMount } from 'svelte';
+import { goto } from "$app/navigation";
 import { sbtcConfig } from '$stores/stores'
 import type { SbtcConfig } from '$types/sbtc_config';
 import Principal from "../common/Principal.svelte";
@@ -14,10 +15,9 @@ import { addresses } from '$lib/stacks_connect';
 import { explorerBtcAddressUrl } from "$lib/utils";
 import Modal from '$lib/components/shared/Modal.svelte';
 import DebugPeginInfo from '$lib/components/common/DebugPeginInfo.svelte';
-import type { PeginRequestI } from 'sbtc-bridge-lib' 
 import { hex } from '@scure/base';
 import { getTestAddresses, sbtcWallets } from 'sbtc-bridge-lib' 
-import type { PegInData, CommitKeysI } from 'sbtc-bridge-lib' 
+import type { PeginRequestI, PegInData, CommitKeysI } from 'sbtc-bridge-lib' 
 
 let piTx:PegInTransactionI;
 let componentKey3 = 0;
@@ -29,11 +29,13 @@ let amountOk = false;
 let peginRequest:PeginRequestI;
 let showModal:boolean;
 let inited = false;
+let custodialReclaim = true;
+let allowPayWithWebWallet = false;
 
 $: showStxAddress = !errorReason;
 $: showAmount = stxAddressOk && !errorReason;
 $: showButton = piTx && piTx.pegInData.amount > 0 && !errorReason;
-$: webWalletPayment = piTx && piTx.maxCommit() >= piTx.pegInData.amount;
+$: webWalletPayment = allowPayWithWebWallet && piTx && piTx.maxCommit() >= piTx.pegInData.amount;
 
 const getExplorerUrl = () => {
   return explorerBtcAddressUrl(piTx.fromBtcAddress)
@@ -105,15 +107,13 @@ const principalUpdated = (event:any) => {
 const commitAddresses = ():CommitKeysI => {
   const addrs = addresses()
   const stacksAddress = (piTx && piTx.pegInData?.stacksAddress) ? piTx.pegInData?.stacksAddress : addrs.stxAddress;
-  let fromBtcAddress = addrs.ordinal; //$sbtcConfig.peginRequest.fromBtcAddress || addrs.ordinal;
+  let fromBtcAddress = addrs.cardinal; //$sbtcConfig.peginRequest.fromBtcAddress || addrs.ordinal;
   let sbtcWalletAddress = $sbtcConfig.sbtcContractData.sbtcWalletAddress as string;
   const sbtcWallet = sbtcWallets.find((o) => o.sbtcAddress === sbtcWalletAddress);
   if (!sbtcWallet) throw new Error('No sBTC Wallet found for address: ' + sbtcWalletAddress)
   let testAddrs;
   if ($sbtcConfig.userSettings.testAddresses) {
     testAddrs = getTestAddresses(CONFIG.VITE_NETWORK);
-    fromBtcAddress = testAddrs.reclaim as string;
-    sbtcWalletAddress = testAddrs.reveal as string;
   }
   const xyWebWalletPubKey = hex.decode(addrs.btcPubkeySegwit1);
   let xOnlyPubKey = hex.encode(xyWebWalletPubKey.subarray(1));
@@ -125,10 +125,9 @@ const commitAddresses = ():CommitKeysI => {
   //const xOnlyPubKey = hex.encode(addrScript.pubkey)
   return {
     fromBtcAddress,
-    reveal: sbtcWalletAddress,
-    revealPub: (testAddrs) ? testAddrs.revealPub : sbtcWallet.pubKey,
-    reclaim: (testAddrs) ? testAddrs.reclaim as string : fromBtcAddress,
-    reclaimPub: (testAddrs) ? testAddrs.reclaimPub : xOnlyPubKey,
+    sbtcWalletAddress,
+    revealPub: $sbtcConfig.keys.deposits.revealPubKey, //(testAddrs) ? testAddrs.revealPub : sbtcWallet.pubKey,
+    reclaimPub: $sbtcConfig.keys.deposits.reclaimPubKey,
     stacksAddress
   }
 }
@@ -166,6 +165,9 @@ const nextStep = (wallet:number) => {
   } else {
     showModal = !showModal;
   }
+}
+const nextModal = () => {
+  goto('/reclaims');
 }
 const closeModal = () => {
   showModal = false;
@@ -214,8 +216,9 @@ onMount(async () => {
 <Modal {showModal} on:click={closeModal} on:close_modal={closeModal}>
   <div class="mb-4"><ScriptHashAddress {piTx}/></div>
   <div slot="title"></div>
-  <div slot="close">
+  <div slot="close" class="d-flex justify-content-around">
     <div class="text-center"><button class="btn btn-outline-info" on:click={closeModal}>CLOSE</button></div>
+    <div class="text-center"><button class="btn btn-outline-info" on:click={nextModal}>NEXT</button></div>
   </div>
   <div slot="debug">
     <div class="row my-3 text-small">
@@ -227,7 +230,9 @@ onMount(async () => {
 </Modal>
 {/if}
 {#if inited}
+  {#if allowPayWithWebWallet}
   <div class="mb-4"><UTXOSelection {utxoData} on:utxo_updated={utxoUpdated} /></div>
+  {/if}
   {#if showStxAddress}
   <div class="mb-4"><Principal {principalData} on:principal_updated={principalUpdated} /></div>
   {/if}
@@ -237,11 +242,15 @@ onMount(async () => {
   {/key}
   {/if}
   {#if errorReason}<div class="text-danger">{@html errorReason}</div>{/if}
+  {#if custodialReclaim}
+  <div class="mb-4 text-small">Note: Reclaims (if necessary) will be sent to the address you send the deposit from</div>
+  {/if}
+
   {#if showButton}
   <div class="row">
     {#if webWalletPayment}
     <div class="col-6">
-      <button class="btn btn-outline-info w-100" type="button" on:click={() => nextStep(1)}>Stacks Web Wallet</button>
+      <button class="btn btn-outline-info w-100" type="button" on:click={() => nextStep(1)}>Web Wallet</button>
     </div>
     {/if}
     <div class="col-6">

--- a/src/lib/components/wrapper/ScriptHashAddress.svelte
+++ b/src/lib/components/wrapper/ScriptHashAddress.svelte
@@ -13,6 +13,7 @@ export let piTx:PegInTransactionI;
 const arg1 =  ($sbtcConfig.userSettings.testAddresses) ? getTestAddresses(CONFIG.VITE_NETWORK) : undefined;
 const peginRequest = piTx?.getOpDropPeginRequest();
 let errorReason:string|undefined;
+let savedPegin:any;
 
 const paymentUri = () => {
   let uri = 'bitcoin:' + peginRequest.commitTxScript!.address
@@ -23,8 +24,9 @@ const paymentUri = () => {
 onMount(async () => {
   try {
     if (peginRequest && peginRequest.commitTxScript && peginRequest.commitTxScript.script && peginRequest.commitTxScript.script.length > 0) 
-      await savePeginCommit(peginRequest)
+    savedPegin = await savePeginCommit(peginRequest)
     const conf:SbtcConfig = $sbtcConfig;
+    conf.pegInMongoId = savedPegin._id
     sbtcConfig.update(() => conf);
   } catch (err) {
     //errorReason = 'Request already being processed with these details - change the amount to send another request.'

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -57,7 +57,7 @@ export function setConfig(search:string) {
     } else if (import.meta.env.MODE === 'development') {
         CONFIG.VITE_BRIDGE_API = 'https://testnet.stx.eco/bridge-api/v1'
         // toggle depending on location / ip address etc
-        //CONFIG.VITE_BRIDGE_API = 'http://localhost:3010/bridge-api/v1'
+        CONFIG.VITE_BRIDGE_API = 'http://localhost:3010/bridge-api/v1'
     }
     //console.log('CONFIG.VITE_BRIDGE_API: ' + CONFIG.VITE_BRIDGE_API);
 }

--- a/src/lib/domain/PegInTransaction.ts
+++ b/src/lib/domain/PegInTransaction.ts
@@ -4,8 +4,7 @@ import { hex } from '@scure/base';
 import type { PeginRequestI } from 'sbtc-bridge-lib' 
 import { fetchUtxoSet, fetchCurrentFeeRates } from "../bridge_api";
 import { decodeStacksAddress, addresses } from '$lib/stacks_connect'
-import { toStorable } from "$lib/utils";
-import { buildDepositPayload, approxTxFees } from 'sbtc-bridge-lib' 
+import { toStorable, buildDepositPayload, approxTxFees } from 'sbtc-bridge-lib' 
 import type { PegInData, CommitKeysI } from 'sbtc-bridge-lib' 
 
 export interface PegInTransactionI {
@@ -83,7 +82,7 @@ export default class PegInTransaction implements PegInTransactionI {
 		me.pegInData = {
 			amount: 0,
 			stacksAddress: commitKeys.stacksAddress,
-			sbtcWalletAddress: commitKeys.reveal,
+			sbtcWalletAddress: commitKeys.sbtcWalletAddress,
 			revealFee: 5000
 		}
 		// utxos have to come from a hosted indexer or external service
@@ -103,7 +102,7 @@ export default class PegInTransaction implements PegInTransactionI {
 		const me = new PegInTransaction();
 		me.net = o.net;
 		//if (!o.fromBtcAddress) throw new Error('No address - use create instead!');
-		me.fromBtcAddress = o.fromBtcAddress || addresses().ordinal;
+		me.fromBtcAddress = o.fromBtcAddress || addresses().cardinal;
 		me.commitKeys = o.commitKeys;
 		me.pegInData = o.pegInData;
 		me.pegInData.sbtcWalletAddress = o.pegInData.sbtcWalletAddress; //'tb1q4zfnhnvfjupe66m4x8sg5d03cja75vfmn27xyq'
@@ -214,6 +213,7 @@ export default class PegInTransaction implements PegInTransactionI {
 			amount: this.pegInData.amount,
 			wallet: 'btc.p2tr(reclaimAddr.pubkey, { script: Script.encode([data, \'DROP\', sbtcWalletAddr.pubkey]) }, this.net, true)',
 			requestType: 'wrap',
+			originator: this.pegInData.stacksAddress,
 			stacksAddress: this.pegInData.stacksAddress,
 			sbtcWalletAddress: this.pegInData.sbtcWalletAddress,
 			revealPub: '',
@@ -253,6 +253,7 @@ export default class PegInTransaction implements PegInTransactionI {
 		]
 		const script = btc.p2tr(btc.TAPROOT_UNSPENDABLE_KEY, scripts, this.net, true);
 		const req:PeginRequestI = {
+			originator: this.pegInData.stacksAddress,
 			fromBtcAddress: this.fromBtcAddress,
 			revealPub: this.commitKeys.revealPub,
 			reclaimPub: this.commitKeys.reclaimPub,

--- a/src/lib/domain/PegOutTransaction.ts
+++ b/src/lib/domain/PegOutTransaction.ts
@@ -150,7 +150,7 @@ export default class PegOutTransaction implements PegOutTransactionI {
 	 * magic bytes not needed in commit tx.
 	 */
 	buildData = (sigOrPrin:string, opDrop:boolean):Uint8Array => {
-		return buildWithdrawalPayload(this.net, this.pegInData.amount, sigOrPrin, opDrop)
+		return buildWithdrawalPayload(this.net, this.pegInData.amount, hex.decode(sigOrPrin), opDrop)
 	}
 
 	getChange = () => {
@@ -239,12 +239,11 @@ export default class PegOutTransaction implements PegOutTransactionI {
 		return {
 			fromBtcAddress: this.fromBtcAddress,
 			status: 1,
-			revealPub: '',
-			reclaimPub: '',
 			amount: this.pegInData.amount,
 			requestType: 'unwrap',
 			mode: 'op_return',
 			wallet: 'any',
+			originator: this.pegInData.stacksAddress,
 			stacksAddress: this.pegInData.stacksAddress,
 			sbtcWalletAddress: this.pegInData.sbtcWalletAddress,
 		};

--- a/src/lib/stacks_connect.ts
+++ b/src/lib/stacks_connect.ts
@@ -62,11 +62,11 @@ export async function fetchSbtcBalance () {
 	sbtcConfig.update((conf:SbtcConfig) => {
 		if (conf.pegInTransaction) {
 			conf.pegInTransaction.pegInData.stacksAddress = adrds.stxAddress;
-			conf.pegInTransaction.fromBtcAddress = adrds.ordinal;
+			conf.pegInTransaction.fromBtcAddress = adrds.cardinal;
 		}
 		if (conf.pegOutTransaction) {
 			conf.pegOutTransaction.pegInData.stacksAddress = adrds.stxAddress;
-			conf.pegOutTransaction.fromBtcAddress = adrds.ordinal;
+			conf.pegOutTransaction.fromBtcAddress = adrds.cardinal;
 		}
 
 		conf.loggedIn = true;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -34,7 +34,7 @@ export function isSupported(address:string) {
   }
   const net = (network === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
   const obj = btc.Address(net).decode(address);
-  if (obj.type !== 'tr') throw new Error(msg)
+  if (obj.type !== 'tr' && obj.type !== 'wpkh' && obj.type !== 'wsh') throw new Error(msg)
   return true;
   /**
   if (obj.type === 'pk') {
@@ -106,73 +106,5 @@ export const keySetForFeeCalculation = {
   priv,
   ecdsaPub: secp.getPublicKey(priv, true),
   schnorrPub: secp.getPublicKey(priv, false)
-}
-
-export function fromStorable(script:any) {
-  if (typeof script.tweakedPubkey === 'string') return script
-  return codifyScript(script, true)
-}
-
-export function toStorable(script:any) {
-  //const copied = JSON.parse(JSON.stringify(script));
-  return codifyScript(script, false)
-}
-
-function codifyScript(script:any, asString:boolean) {
-  return {
-    address: script.address,
-    script: codify(script.script, asString),
-    paymentType: (script.type) ? script.type : script.paymentType,
-    witnessScript: codify(script.witnessScript, asString),
-    redeemScript: codify(script.redeemScript, asString),
-    leaves: (script.leaves) ? codifyLeaves(script.leaves, asString) : undefined,
-    tapInternalKey: codify(script.tapInternalKey, asString),
-    tapLeafScript: (script.tapLeafScript) ? codifyTapLeafScript(script.tapLeafScript, asString) : undefined,
-    tapMerkleRoot: codify(script.tapMerkleRoot, asString),
-    tweakedPubkey: codify(script.tweakedPubkey, asString),
-  }
-
-}
-
-function codifyTapLeafScript(tapLeafScript:any, asString:boolean) {
-  if (tapLeafScript[0]) {
-    const level0 = tapLeafScript[0]
-    if (level0[0]) tapLeafScript[0][0].internalKey = codify(tapLeafScript[0][0].internalKey, asString)
-    if (level0[0]) tapLeafScript[0][0].merklePath[0] = codify(tapLeafScript[0][0].merklePath[0], asString)
-    if (level0[1]) tapLeafScript[0][1] = codify(tapLeafScript[0][1], asString)
-  }
-  if (tapLeafScript[1]) {
-    const level1 = tapLeafScript[1]
-    if (level1[0]) tapLeafScript[1][0].internalKey = codify(tapLeafScript[1][0].internalKey, asString)
-    if (level1[0]) tapLeafScript[1][0].merklePath[0] = codify(tapLeafScript[1][0].merklePath[0], asString)
-    if (level1[1]) tapLeafScript[1][1] = codify(tapLeafScript[1][1], asString)
-  }
-  return tapLeafScript;
-}
-
-function codify (arg:unknown, asString:boolean) {
-  if (!arg) return;
-  if (typeof arg === 'string') {
-    return hex.decode(arg)
-  } else {
-    return hex.encode(arg as Uint8Array)
-  }
-}
-function codifyLeaves(leaves:any, asString:boolean) {
-  if (leaves[0]) {
-    const level1 = leaves[0]
-    if (level1.controlBlock) leaves[0].controlBlock = codify(leaves[0].controlBlock, asString)
-    if (level1.hash) leaves[0].hash = codify(leaves[0].hash, asString)
-    if (level1.script) leaves[0].script = codify(leaves[0].script, asString)
-    if (level1.path && level1.path[0]) leaves[0].path[0] = codify(leaves[0].path[0], asString)
-  }
-  if (leaves[1]) {
-    const level1 = leaves[1]
-    if (level1.controlBlock) leaves[1].controlBlock = codify(leaves[1].controlBlock, asString)
-    if (level1.hash) leaves[1].hash = codify(leaves[1].hash, asString)
-    if (level1.script) leaves[1].script = codify(leaves[1].script, asString)
-    if (level1.path && level1.path[0]) leaves[1].path[0] = codify(leaves[1].path[0], asString)
-  }
-  return leaves;
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,8 +14,8 @@ import { defaultSbtcConfig } from '$lib/sbtc';
 import { COMMS_ERROR } from '$lib/utils.js'
 import { fetchSbtcData } from "$lib/bridge_api";
 import { fetchSbtcBalance } from "$lib/stacks_connect";
-import { fetchUtxoSet, fetchCurrentFeeRates } from "$lib/bridge_api";
-import type { SbtcContractDataI } from 'sbtc-bridge-lib';
+import { fetchUtxoSet, fetchCurrentFeeRates, fetchKeys } from "$lib/bridge_api";
+import type { SbtcContractDataI, KeySet } from 'sbtc-bridge-lib';
 
 console.log('process.env: ', import.meta.env);
 setConfig($page.url.search);
@@ -67,8 +67,9 @@ const initApplication = async () => {
     conf.loggedIn = true;
     await fetchSbtcBalance();
   }
+  const keys:KeySet = await fetchKeys();
+  conf.keys = keys;
   conf.sbtcContractData = data;
-  //conf.sbtcContractData.sbtcWalletAddress = 'tb1q4zfnhnvfjupe66m4x8sg5d03cja75vfmn27xyq'
   sbtcConfig.update(() => conf);
 }
 

--- a/src/types/sbtc_config.ts
+++ b/src/types/sbtc_config.ts
@@ -1,11 +1,10 @@
 import type { PegInTransactionI } from "$lib/domain/PegInTransaction";
 import type { PegOutTransactionI } from "$lib/domain/PegOutTransaction";
-import type { PeginRequestI } from 'sbtc-bridge-lib' 
-import type { SbtcContractDataI } from 'sbtc-bridge-lib';
-import type { SbtcBalance } from 'sbtc-bridge-lib' 
+import type { PeginRequestI, SbtcContractDataI, SbtcBalance, KeySet } from 'sbtc-bridge-lib' 
 
 export type SbtcConfig = {
   sbtcWalletAddressInfo?: any;
+  pegInMongoId?: string;
   btcFeeRates?: any;
   loggedIn: boolean;
   pegInTransaction?:PegInTransactionI;
@@ -17,6 +16,7 @@ export type SbtcConfig = {
   peginRequest:PeginRequestI;
   userSettings:SbtcUserSettingI;
   sbtcContractData: SbtcContractDataI;
+  keys: KeySet;
 };
 
 export type SbtcUserSettingI = {

--- a/tests/pegin.test.ts
+++ b/tests/pegin.test.ts
@@ -9,6 +9,8 @@ import { pegin1 } from './data/data_pegin_p2wpkh'
 import { sha256 } from '@noble/hashes/sha256';
 import { MAGIC_BYTES_TESTNET, MAGIC_BYTES_MAINNET, PEGIN_OPCODE } from 'sbtc-bridge-lib'
 import { c32address } from 'c32check';
+import { schnorr } from '@noble/curves/secp256k1';
+
 
 const addr = 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5'
 const addrM = 'SP1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28GBQA1W0F'
@@ -33,6 +35,13 @@ describe('suite', () => {
 
   beforeEach(async () => {
     // cant fetch mock here as only first mock is recognised
+  })
+
+  it.concurrent('Create random schnorr keys', async () => {
+    const privSchnorr = schnorr.utils.randomPrivateKey();
+    const pubSchnorr = schnorr.getPublicKey(privSchnorr);
+    console.log('privSchnorr: ' + hex.encode(privSchnorr));
+    console.log('pubSchnorr: ' + hex.encode(pubSchnorr));
   })
 
   it.concurrent('PegInTransaction.constructor() returns pegin builder in state not ready', async () => {

--- a/tests/pegout.test.ts
+++ b/tests/pegout.test.ts
@@ -9,7 +9,7 @@ import { pegout1 } from './data/data_pegout_p2wpkh'
 import { sha256 } from '@noble/hashes/sha256';
 import { concatByteArrays } from '$lib/structured-data.js'
 import { MAGIC_BYTES_TESTNET, MAGIC_BYTES_MAINNET, PEGOUT_OPCODE } from 'sbtc-bridge-lib'
-import { uint8ToAmount, amountToUint8, parseWithdrawalPayload } from 'sbtc-bridge-lib' 
+import { uint8ToAmount, amountToUint8 } from 'sbtc-bridge-lib' 
 
 const priv = secp.utils.randomPrivateKey()
 type KeySet = {
@@ -238,7 +238,7 @@ describe('suite', () => {
     const myPeg:PegOutTransactionI = await PegOutTransaction.hydrate(JSON.parse(JSON.stringify(pegout1)));
     myPeg.net = btc.TEST_NETWORK;
     const data = myPeg.buildData(sig, false);
-    expect(hex.encode(data.slice(0,2))).equals(MAGIC_BYTES_MAINNET);
+    expect(hex.encode(data.slice(0,2))).equals(MAGIC_BYTES_TESTNET);
   })
 
   it.concurrent('PegOutTransaction.buildData() data built reflects mainnet network', async () => {

--- a/tests/reveal.data.ts
+++ b/tests/reveal.data.ts
@@ -121,12 +121,15 @@ export const utxos_nrsp = {
 export const commitTx:PeginRequestI = {
   _id: "64458cd71f66c6ef1074c5bb",
   fromBtcAddress: 'tb1qxj5tpfsz836fyh5c3gfu2t9spjpzf924etnrsp',
+  revealPub: 'tb1qxj5tpfsz836fyh5c3gfu2t9spjpzf924etnrsp',
+  reclaimPub: 'tb1qxj5tpfsz836fyh5c3gfu2t9spjpzf924etnrsp',
   status: 2,
   tries: 0,
   mode: 'op_drop_tr',
   amount: 202020,
   requestType: 'wrap',
   wallet: 'any',
+  originator: 'ST29N24XJPW2WRVF6S2JWBC3TJBGBA5EXPSC03Y0G',
   stacksAddress: 'ST29N24XJPW2WRVF6S2JWBC3TJBGBA5EXPSC03Y0G',
   sbtcWalletAddress: 'tb1p4m8lyp5m3tjfwq2288429rk7sxnp5xjqslxkvatkujtsr8kkxlgqu9r4cd',
   commitTxScript: {

--- a/tests/reveal.test.ts
+++ b/tests/reveal.test.ts
@@ -140,7 +140,7 @@ describe('suite', () => {
     });
     revealTx.fee = 5000
 
-    const tx = await revealTx.buildTransaction(false, true);
+    const tx = await revealTx.buildTransaction(false);
     //expect(tx.inputsLength).equals(2)
     expect(tx.outputsLength).equals(1)
  


### PR DESCRIPTION
Moves the key pairs for the embedded taproot scripts server side. Having them as custodial keys means

a) the bridge can generate test reveal transaction
b) the bridge can refund users bitcoin if no spent by the reveal